### PR TITLE
Update expo-blur dependency to version 14.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	},
 	"dependencies": {
 		"expo": "~52.0.11",
+		"expo-blur": "~14.0.1",
 		"expo-constants": "~17.0.3",
 		"expo-dev-client": "~5.0.4",
 		"expo-linking": "~7.0.3",

--- a/src/app/(tabs)/(songs)/_layout.tsx
+++ b/src/app/(tabs)/(songs)/_layout.tsx
@@ -1,3 +1,4 @@
+import { StackScreenWithSearchBar } from '@/constants/layout'
 import { defaultStyles } from '@/styles'
 import { Stack } from 'expo-router'
 import { View } from 'react-native'
@@ -6,7 +7,10 @@ const SongsScreenLayout = () => {
 	return (
 		<View style={defaultStyles.container}>
 			<Stack>
-				<Stack.Screen name="index" options={{ headerTitle: 'Songs' }} />
+				<Stack.Screen
+					name="index"
+					options={{ ...StackScreenWithSearchBar, headerTitle: 'Songs' }}
+				/>
 			</Stack>
 		</View>
 	)

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@ import { colors, fontSize } from '@/constants/tokens'
 import { Tabs } from 'expo-router'
 import { BlurView } from 'expo-blur'
 import { StyleSheet } from 'react-native'
+import { FontAwesome, MaterialCommunityIcons, Ionicons, FontAwesome6 } from '@expo/vector-icons'
 const TabsNavigation = () => {
 	return (
 		<Tabs
@@ -32,10 +33,38 @@ const TabsNavigation = () => {
 				),
 			}}
 		>
-			<Tabs.Screen name="favorites" />
-			<Tabs.Screen name="playlists" />
-			<Tabs.Screen name="(songs)" />
-			<Tabs.Screen name="artists" />
+			<Tabs.Screen
+				name="favorites"
+				options={{
+					title: 'Favorites',
+					tabBarIcon: ({ color }) => <FontAwesome name="heart" size={20} color={color} />,
+				}}
+			/>
+			<Tabs.Screen
+				name="playlists"
+				options={{
+					title: 'Playlists',
+					tabBarIcon: ({ color }) => (
+						<MaterialCommunityIcons name="playlist-play" size={28} color={color} />
+					),
+				}}
+			/>
+			<Tabs.Screen
+				name="(songs)"
+				options={{
+					title: 'Songs',
+					tabBarIcon: ({ color }) => (
+						<Ionicons name="musical-notes-sharp" size={24} color={color} />
+					),
+				}}
+			/>
+			<Tabs.Screen
+				name="artists"
+				options={{
+					title: 'Artists',
+					tabBarIcon: ({ color }) => <FontAwesome6 name="users-line" size={20} color={color} />,
+				}}
+			/>
 		</Tabs>
 	)
 }

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -1,8 +1,37 @@
+import { colors, fontSize } from '@/constants/tokens'
 import { Tabs } from 'expo-router'
-
+import { BlurView } from 'expo-blur'
+import { StyleSheet } from 'react-native'
 const TabsNavigation = () => {
 	return (
-		<Tabs>
+		<Tabs
+			screenOptions={{
+				tabBarActiveTintColor: colors.primary,
+				tabBarLabelStyle: {
+					fontSize: fontSize.xs,
+					fontWeight: '500',
+				},
+				headerShown: false,
+				tabBarStyle: {
+					position: 'absolute',
+					borderTopLeftRadius: 20,
+					borderTopRightRadius: 20,
+					borderTopWidth: 0,
+					paddingTop: 8,
+				},
+				tabBarBackground: () => (
+					<BlurView
+						intensity={95}
+						style={{
+							...StyleSheet.absoluteFillObject,
+							overflow: 'hidden',
+							borderTopLeftRadius: 20,
+							borderTopRightRadius: 20,
+						}}
+					/>
+				),
+			}}
+		>
 			<Tabs.Screen name="favorites" />
 			<Tabs.Screen name="playlists" />
 			<Tabs.Screen name="(songs)" />

--- a/src/app/(tabs)/artists/_layout.tsx
+++ b/src/app/(tabs)/artists/_layout.tsx
@@ -1,3 +1,4 @@
+import { StackScreenWithSearchBar } from '@/constants/layout'
 import { defaultStyles } from '@/styles'
 import { Stack } from 'expo-router'
 import { View } from 'react-native'
@@ -6,7 +7,10 @@ const ArtistsScreenLayout = () => {
 	return (
 		<View style={defaultStyles.container}>
 			<Stack>
-				<Stack.Screen name="index" options={{ headerTitle: 'Artists' }} />
+				<Stack.Screen
+					name="index"
+					options={{ ...StackScreenWithSearchBar, headerTitle: 'Artists' }}
+				/>
 			</Stack>
 		</View>
 	)

--- a/src/app/(tabs)/favorites/_layout.tsx
+++ b/src/app/(tabs)/favorites/_layout.tsx
@@ -1,3 +1,4 @@
+import { StackScreenWithSearchBar } from '@/constants/layout'
 import { defaultStyles } from '@/styles'
 import { Stack } from 'expo-router'
 import { View } from 'react-native'
@@ -6,7 +7,10 @@ const FavoriteScreenLayout = () => {
 	return (
 		<View style={defaultStyles.container}>
 			<Stack>
-				<Stack.Screen name="index" options={{ headerTitle: 'Favorites' }} />
+				<Stack.Screen
+					name="index"
+					options={{ ...StackScreenWithSearchBar, headerTitle: 'Favorites' }}
+				/>
 			</Stack>
 		</View>
 	)

--- a/src/app/(tabs)/playlists/_layout.tsx
+++ b/src/app/(tabs)/playlists/_layout.tsx
@@ -1,3 +1,4 @@
+import { StackScreenWithSearchBar } from '@/constants/layout'
 import { defaultStyles } from '@/styles'
 import { Stack } from 'expo-router'
 import { View } from 'react-native'
@@ -6,7 +7,10 @@ const PlaylistsScreenLayout = () => {
 	return (
 		<View style={defaultStyles.container}>
 			<Stack>
-				<Stack.Screen name="index" options={{ headerTitle: 'Playlists' }} />
+				<Stack.Screen
+					name="index"
+					options={{ ...StackScreenWithSearchBar, headerTitle: 'Playlists' }}
+				/>
 			</Stack>
 		</View>
 	)

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,0 +1,16 @@
+import { NativeStackNavigationOptions } from '@react-navigation/native-stack'
+import { colors } from './tokens'
+
+export const StackScreenWithSearchBar: NativeStackNavigationOptions = {
+	headerLargeTitle: true,
+	headerLargeStyle: {
+		backgroundColor: colors.background,
+	},
+	headerLargeTitleStyle: {
+		color: colors.text,
+	},
+	headerTintColor: colors.text,
+	headerTransparent: true,
+	headerBlurEffect: 'prominent',
+	headerShadowVisible: false,
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3446,6 +3446,11 @@ expo-asset@~11.0.1:
     invariant "^2.2.4"
     md5-file "^3.2.3"
 
+expo-blur@~14.0.1:
+  version "14.0.1"
+  resolved "https://registry.yarnpkg.com/expo-blur/-/expo-blur-14.0.1.tgz#4bdbec43b5015891990e78d31d8ff2f1f5d27464"
+  integrity sha512-3Q6jFBLbY8n2vwk28ycUC+eIlVhnlqwkXUKk/Lfaj+SGV3AZMQyrixe7OYwJdUfwqETBrnYYMB6uNrJzOSbG+g==
+
 expo-constants@~17.0.0, expo-constants@~17.0.3:
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-17.0.3.tgz#a05b38e0417d59759ece1642b4d483889e04dbda"


### PR DESCRIPTION
This pull request updates the expo-blur dependency to version 14.0.1. It also includes style changes to attach blur style into the navbar and updates to the tab navigation icons and titles.